### PR TITLE
gha: also run tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
         script/validate/vendor
         go build -i .
         make check
+        make test-full
+        make test-race
+        make integration
         make build
         make binaries
         if [ "$GOOS" = "linux" ]; then make coverage ; fi


### PR DESCRIPTION
testing https://github.com/distribution/distribution/pull/3520

For some reason, travis was running 'check' (linting), and 'build', but
none of the test targets were run.

This patch adds the test targets to the github actions workflow.
